### PR TITLE
Fix properties attribute being a vector rather than single element

### DIFF
--- a/R/get_importances.R
+++ b/R/get_importances.R
@@ -56,7 +56,7 @@ get_pdp_importance = function(learner, test_tsk) {
   pred = iml::Predictor$new(model = learner, data = test_tsk$data(),
     y = test_tsk$target_names)
   if (learner$task_type == "classif") {
-    if (learner$state$train_task$properties == "multiclass") {
+    if ("multiclass" %in% learner$state$train_task$properties) {
       # get class frequencies for weighting
       tgtname = test_tsk$target_names
       weights = test_tsk$data(cols = learner$state$train_task$target_names)[, .N/test_tsk$nrow, by = tgtname]
@@ -70,7 +70,7 @@ get_pdp_importance = function(learner, test_tsk) {
   # currently just sum over variances weighted by class frequencies
   imp = map(pdp$results, function(dt) {
     dt = as.data.table(dt)
-  if (learner$task_type == "classif" && learner$state$train_task$properties == "multiclass") {
+  if (learner$task_type == "classif" && "multiclass" %in% learner$state$train_task$properties) {
       sdvals = dt[, stats::sd(.value), by = .class]
         sdvals = merge(sdvals, weights, by.x = ".class", by.y = tgtname)
         sum(sdvals$V1*sdvals$weights)

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,15 +3,15 @@
 get_default_measures = function(task_type, properties = NULL, predict_type = NULL) {
   keys = if (task_type == "classif") {
     if (predict_type == "response") {
-      if (properties == "twoclass") {
+      if ("twoclass" %in% properties) {
         mlr_measures$mget(c("classif.acc", "classif.bacc", "classif.fbeta", "classif.mcc"))
-      } else if (properties == "multiclass") {
+      } else if ("multiclass" %in% properties) {
         mlr_measures$mget(c("classif.acc", "classif.bacc"))
       }
     } else if (predict_type == "prob") {
-      if (properties == "twoclass") {
+      if ("twoclass" %in% properties) {
         mlr_measures$mget(c("classif.auc", "classif.fbeta", "classif.bbrier", "classif.mcc"))
-      } else if (properties == "multiclass") {
+      } else if ("multiclass" %in% properties) {
         mlr_measures$mget(c("classif.mauc_aunp", "classif.mbrier"))
       }
 
@@ -33,7 +33,7 @@ get_default_fairness_measures = function(task_type, properties = NULL, predict_t
     list(msr("fairness", operation = groupdiff_absdiff, base_measure = msr("regr.rmse")),
       msr("fairness", operation = groupdiff_absdiff, base_measure = msr("regr.mae"))
     )
-  } else if (task_type == "classif" && properties == "multiclass") {
+  } else if (task_type == "classif" && "multiclass" %in% properties) {
     list(msr("fairness", operation = groupdiff_absdiff, base_measure = msr("classif.acc")))
   } else {
     NA_character_


### PR DESCRIPTION
Hello,

Thanks for creating this package! I have run into a small issue when trying it out: the "properties" attribute for a task is generally a vector, but the code in mlr3summary assumes that it consists of a single element. This PR converts a few `==` comparisons to `%in%` so that the code works when there are multiple properties for a task. In particular, this occurs when stratification, weights, or groups are defined for a task: https://mlr3.mlr-org.com/reference/Task.html#active-bindings

Cheers,
Chris