### PR TITLE
fix: use correct min R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Description: Concise and interpretable summaries for machine learning
     effects, and fairness metrics.
 License: LGPL-3
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.5.0)
 Imports:
     backports,
     checkmate (>= 2.0.0),


### PR DESCRIPTION
We actually need 3.5 due to serialization, see CRAN actually requiring 3.5 for the package: https://cran.r-project.org/web/packages/mlr3summary/index.html